### PR TITLE
Update FleetReSortie.cs

### DIFF
--- a/Grabacr07.KanColleWrapper/Models/FleetReSortie.cs
+++ b/Grabacr07.KanColleWrapper/Models/FleetReSortie.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Grabacr07.KanColleWrapper/Models/FleetReSortie.cs
+++ b/Grabacr07.KanColleWrapper/Models/FleetReSortie.cs
@@ -108,7 +108,7 @@ namespace Grabacr07.KanColleWrapper.Models
 
 			var reason = CanReSortieReason.NoProblem;
 
-			if (ships.Any(s => (s.HP.Current / (double)s.HP.Maximum) <= 0.5))
+			if (ships.Any(s => (s.HP.Current / (double)s.HP.Maximum) <= 0.25))
 			{
 				reason |= CanReSortieReason.Wounded;
 			}


### PR DESCRIPTION
Sinks can't sink at moderate damage, so make it notify at severely damaged. Which was what was happening in Musashi's release.
